### PR TITLE
chore: add package-lock.json to semantic release bot commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "themeprovider-storybook",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/release.config.js
+++ b/release.config.js
@@ -21,7 +21,7 @@ module.exports = {
       },
     ],
     {
-      assets: ["package.json", "CHANGELOG.md"],
+      assets: ["package.json", "CHANGELOG.md", "package-lock.json"],
       message: "chore(release): ${nextRelease.version} [ci skip] ${nextRelease.notes}",
       path: "@semantic-release/git",
     },


### PR DESCRIPTION
* currently `npm publish` updates `package-lock.json` which is not being committed as part of the `chore(release)`, this pr fixes this. 