### PR TITLE
fix: allow theme buttons to wrap when many themes

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -12,6 +12,8 @@ const Row = styled.div`
   display: flex;
   height: auto;
   padding: 15px;
+  flex-wrap: wrap;
+  align-content: flex-start;
 `;
 
 const Button = styled.button<StyledButton>`
@@ -34,7 +36,7 @@ const Button = styled.button<StyledButton>`
   white-space: nowrap;
   user-select: none;
   opacity: 1;
-  margin: 0 1em 0 0;
+  margin: 0 1em 1em 0;
   max-height: 3em;
   outline: none;
   font-family: inherit;


### PR DESCRIPTION
Hi @semoal, first of all thanks for your great addon!

## Issue
I noticed one issue when using `themeprovider-storybook` with many themes - they get all squeezed together and become illegible  (see screenshot below):
<img width="1120" alt="Screen Shot 2021-05-24 at 8 56 25 PM" src="https://user-images.githubusercontent.com/1680390/119425682-d440bb00-bcd5-11eb-892e-40e1e3f2f34c.png">

## Suggested fix
I've made some minor changes to the styles to allow the theme-buttons to wrap if they fill up the full width available:
<img width="820" alt="Screen Shot 2021-05-24 at 9 08 49 PM" src="https://user-images.githubusercontent.com/1680390/119425817-123ddf00-bcd6-11eb-8d0f-533834920cb8.png">
<img width="568" alt="Screen Shot 2021-05-24 at 9 09 04 PM" src="https://user-images.githubusercontent.com/1680390/119425820-123ddf00-bcd6-11eb-9568-e4fb3fdf7bd7.png">

There is no change if all of the themes fit into the first line:
<img width="846" alt="Screen Shot 2021-05-24 at 9 27 21 PM" src="https://user-images.githubusercontent.com/1680390/119426310-f555db80-bcd6-11eb-8d4d-25a44fcde4a3.png">

Tested in the latest Chrome, FF, Safari and Edge.

## Test Scaffolding 
To test this behaviour and add the scaffolding to add 17 themes you could instead [merge the `docs/allow-theme-buttons-to-wrap-demo` branch](https://github.com/semoal/themeprovider-storybook/compare/master...micmro:docs/allow-theme-buttons-to-wrap-demo?expand=1) instead.

In a just I've added some copies of `THEMES[0]`:
```ts
const MANY_THEMES = THEMES.concat(new Array(15).fill(null).map((_, i) => ({
  ...THEMES[0],
  name: `Theme ${i + 1}`,
  backgroundColor: `#${i.toString(16).repeat(6)}`,
})))
```